### PR TITLE
Rewrite datastore interface

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,15 +1,13 @@
 package cmd
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
-	"html/template"
 	"io"
 	"os"
 	"os/exec"
-	"path"
-	"regexp"
-	"time"
+	"strings"
 
 	shellquote "github.com/kballard/go-shellquote"
 	homedir "github.com/mitchellh/go-homedir"
@@ -18,12 +16,109 @@ import (
 	"github.com/taylorskalyo/stno/datastore"
 )
 
-const defaultTemplate string = `title = ""
-datetime = {{.DateTime}}
-notes = ""`
+const stnoDir string = "~/.stno"
 
-type templateData struct {
-	DateTime string
+// addCmd adds a new entry to the notebook.
+var addCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a stno entry",
+	Long:  `New entries will be opened in your default editor.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Create entry
+		dir, err := homedir.Expand(stnoDir)
+		if err != nil {
+			fmt.Printf("Could not expand path %s: %s.\n", stnoDir, err.Error())
+			os.Exit(1)
+		}
+		n := datastore.FileStore{Dir: dir}
+		entry, err := n.NewEntryWriteCloser("entry")
+		if err != nil {
+			fmt.Printf("Failed to create entry %s: %s.\n", "entry", err.Error())
+			os.Exit(1)
+		}
+
+		contents := ""
+		for {
+			contents, err = editString(contents)
+			if _, err = toml.Load(contents); err != nil {
+				fmt.Printf("Could not parse TOML: %s. Try again? ", err.Error())
+				if !confirm() {
+					break
+				}
+			} else {
+				break
+			}
+		}
+
+		if _, err = io.WriteString(entry, contents); err != nil {
+			fmt.Printf("Failed to save notebook entry: %s.\n", err.Error())
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(addCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// addCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// addCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func editString(str string) (string, error) {
+	// Create temporary file
+	tmpfile, err := datastore.TempFile("", "stno", ".toml")
+	if err != nil {
+		return str, err
+	}
+	defer os.Remove(tmpfile.Name())
+	if _, err = io.WriteString(tmpfile, str); err != nil {
+		return str, err
+	}
+
+	fi, err := tmpfile.Stat()
+	if err != nil {
+		return str, err
+	}
+	oldModTime := fi.ModTime()
+	if err := tmpfile.Close(); err != nil {
+		return str, err
+	}
+	tmpfile.Close()
+
+	// Open file in editor
+	if err = openEditor(tmpfile.Name()); err != nil {
+		return str, err
+	}
+
+	rc, err := os.Open(tmpfile.Name())
+	if err != nil {
+		return str, err
+	}
+	defer rc.Close()
+
+	// Return original string if there were no changes
+	fi, err = rc.Stat()
+	if err != nil {
+		return str, err
+	}
+	if oldModTime == fi.ModTime() {
+		fmt.Println("Aborting due to no changes.")
+		os.Exit(1)
+	}
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(rc)
+	if err != nil {
+		return str, err
+	}
+	return buf.String(), nil
 }
 
 func openEditor(path string) error {
@@ -50,132 +145,19 @@ func openEditor(path string) error {
 	return nil
 }
 
-// newTemplateData holds values that can be substituted into a template.
-func newTemplateData() templateData {
-	return templateData{
-		DateTime: time.Now().Format(time.RFC3339),
+func confirm() bool {
+	fmt.Printf("(y/N): ")
+	r := bufio.NewReader(os.Stdin)
+	s, err := r.ReadString('\n')
+	if err != nil {
+		panic(err)
 	}
-}
 
-func stnoDir(name string) (string, error) {
-	return homedir.Expand(path.Join("~/.stno", name))
-}
+	s = strings.TrimSpace(s)
+	s = strings.ToLower(s)
 
-// addCmd adds a new entry to the notebook.
-var addCmd = &cobra.Command{
-	Use:   "add",
-	Short: "Add a stno entry",
-	Long:  `New entries will be opened in your default editor.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		// Create temporary file
-		tmpfile, err := datastore.TempFile("", "stno", ".toml")
-		if err != nil {
-			fmt.Printf("Failed to create temporary file: %s.\n", err.Error())
-			os.Exit(1)
-		}
-		defer os.Remove(tmpfile.Name())
-
-		// Write template to file
-		t, err := template.New("default").Parse(defaultTemplate)
-		if err != nil {
-			fmt.Printf("Failed to generate notebook template: %s.\n", err.Error())
-			os.Exit(1)
-		}
-		err = t.Execute(tmpfile, newTemplateData())
-		if err != nil {
-			fmt.Printf("Failed to apply notebook template: %s.\n", err.Error())
-			os.Exit(1)
-		}
-		fi, err := tmpfile.Stat()
-		if err != nil {
-			fmt.Printf("Failed to stat temporary file %s: %s.\n", tmpfile.Name(), err.Error())
-			os.Exit(1)
-		}
-		oldModTime := fi.ModTime()
-		if err := tmpfile.Close(); err != nil {
-			fmt.Printf("Failed to close temporary file %s: %s.\n", tmpfile.Name(), err.Error())
-			os.Exit(1)
-		}
-
-		// Open file in editor
-		if err = openEditor(tmpfile.Name()); err != nil {
-			fmt.Printf("Failed to open editor: %s.\n", err.Error())
-			os.Exit(1)
-		}
-
-		rc, err := os.Open(tmpfile.Name())
-		if err != nil {
-			fmt.Printf("Failed to open temporary file %s: %s.\n", tmpfile.Name(), err.Error())
-			os.Exit(1)
-		}
-		defer rc.Close()
-
-		// Return if there were no changes
-		fi, err = rc.Stat()
-		if err != nil {
-			fmt.Printf("Failed to stat temporary file %s: %s.\n", tmpfile.Name(), err.Error())
-			os.Exit(1)
-		}
-		if oldModTime == fi.ModTime() {
-			fmt.Println("Aborting due to empty entry.")
-			os.Exit(1)
-		}
-
-		// Lint file
-		tree, err := toml.LoadReader(rc)
-		if err != nil {
-			fmt.Printf("Invalid toml: %s.\n", err.Error())
-			os.Exit(1)
-		}
-		rc.Seek(0, 0)
-
-		// Copy contents from temp file to entry file
-		dir, err := stnoDir(notebook)
-		if err != nil {
-			fmt.Printf("Failed to determine notebook directory: %s.\n", err.Error())
-			os.Exit(1)
-		}
-		ds, err := datastore.CreateFileStore(dir)
-		if err != nil {
-			fmt.Printf("Failed to create notebook data store: %s.\n", err.Error())
-			os.Exit(1)
-		}
-		var buf bytes.Buffer
-		datetime, ok := tree.Get("datetime").(time.Time)
-		if ok {
-			buf.WriteString(fmt.Sprintf("%d", datetime.Unix()))
-			buf.WriteString("-")
-		}
-		title, ok := tree.Get("title").(string)
-		if ok {
-			r := regexp.MustCompile("[^A-Za-z0-9_-]+")
-			buf.WriteString(r.ReplaceAllString(title, "-"))
-			buf.WriteString("-")
-		}
-		_, wc, err := ds.NewUniqueWriteCloser(buf.String())
-		if err != nil {
-			fmt.Printf("Failed to create notebook entry: %s.\n", err.Error())
-			os.Exit(1)
-		}
-		defer wc.Close()
-		_, err = io.Copy(wc, rc)
-		if err != nil {
-			fmt.Printf("Failed to save notebook entry: %s.\n", err.Error())
-			os.Exit(1)
-		}
-	},
-}
-
-func init() {
-	RootCmd.AddCommand(addCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// addCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// addCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	if s == "y" || s == "yes" {
+		return true
+	}
+	return false
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,22 +1,15 @@
 package cmd
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"strings"
 
-	shellquote "github.com/kballard/go-shellquote"
 	homedir "github.com/mitchellh/go-homedir"
 	toml "github.com/pelletier/go-toml"
 	"github.com/spf13/cobra"
 	"github.com/taylorskalyo/stno/datastore"
 )
-
-const stnoDir string = "~/.stno"
 
 // addCmd adds a new entry to the notebook.
 var addCmd = &cobra.Command{
@@ -69,95 +62,4 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// addCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}
-
-func editString(str string) (string, error) {
-	// Create temporary file
-	tmpfile, err := datastore.TempFile("", "stno", ".toml")
-	if err != nil {
-		return str, err
-	}
-	defer os.Remove(tmpfile.Name())
-	if _, err = io.WriteString(tmpfile, str); err != nil {
-		return str, err
-	}
-
-	fi, err := tmpfile.Stat()
-	if err != nil {
-		return str, err
-	}
-	oldModTime := fi.ModTime()
-	if err := tmpfile.Close(); err != nil {
-		return str, err
-	}
-	tmpfile.Close()
-
-	// Open file in editor
-	if err = openEditor(tmpfile.Name()); err != nil {
-		return str, err
-	}
-
-	rc, err := os.Open(tmpfile.Name())
-	if err != nil {
-		return str, err
-	}
-	defer rc.Close()
-
-	// Return original string if there were no changes
-	fi, err = rc.Stat()
-	if err != nil {
-		return str, err
-	}
-	if oldModTime == fi.ModTime() {
-		fmt.Println("Aborting due to no changes.")
-		os.Exit(1)
-	}
-
-	buf := new(bytes.Buffer)
-	_, err = buf.ReadFrom(rc)
-	if err != nil {
-		return str, err
-	}
-	return buf.String(), nil
-}
-
-func openEditor(path string) error {
-	editor := os.Getenv("EDITOR")
-	if editor == "" {
-		editor = "editor"
-	}
-
-	args, err := shellquote.Split(editor)
-	if err != nil {
-		return err
-	}
-
-	editor = args[0]
-	args = append(args[1:], path)
-	cmd := exec.Command(editor, args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func confirm() bool {
-	fmt.Printf("(y/N): ")
-	r := bufio.NewReader(os.Stdin)
-	s, err := r.ReadString('\n')
-	if err != nil {
-		panic(err)
-	}
-
-	s = strings.TrimSpace(s)
-	s = strings.ToLower(s)
-
-	if s == "y" || s == "yes" {
-		return true
-	}
-	return false
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,25 +12,36 @@ import (
 	"github.com/taylorskalyo/stno/datastore"
 )
 
-// addCmd adds a new entry to the notebook.
 var addCmd = &cobra.Command{
-	Use:   "add",
-	Short: "Add a stno entry",
-	Long:  `New entries will be opened in your default editor.`,
+	Use:   "add path",
+	Short: "Add an entry to your stno notebook",
+	Long: `Add an entry to your stno notebook
+
+New entries will be opened in your default editor (specified by the EDITOR
+environment variable). If the entry is not valid TOML, you will be prompted to
+revise the entry. This command takes a path. This path is relative to the stno
+directory (defaults to ~/.stno). `,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return errors.New("add requires a path")
+		}
+		return nil
+	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Create entry
+		// Open entry for writing
 		dir, err := homedir.Expand(stnoDir)
 		if err != nil {
 			fmt.Printf("Could not expand path %s: %s.\n", stnoDir, err.Error())
 			os.Exit(1)
 		}
-		n := datastore.FileStore{Dir: dir}
-		entry, err := n.NewEntryWriteCloser("entry")
+		ds := datastore.FileStore{Dir: dir}
+		entry, err := ds.NewEntryWriteCloser(args[0])
 		if err != nil {
-			fmt.Printf("Failed to create entry %s: %s.\n", "entry", err.Error())
+			fmt.Printf("Failed to create entry %s: %s.\n", args[0], err.Error())
 			os.Exit(1)
 		}
 
+		// Edit entry contents in temporary location
 		contents := ""
 		for {
 			contents, err = editString(contents)
@@ -43,6 +55,7 @@ var addCmd = &cobra.Command{
 			}
 		}
 
+		// Write contents to entry
 		if _, err = io.WriteString(entry, contents); err != nil {
 			fmt.Printf("Failed to save notebook entry: %s.\n", err.Error())
 			os.Exit(1)

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	shellquote "github.com/kballard/go-shellquote"
+	"github.com/taylorskalyo/stno/datastore"
+)
+
+const stnoDir string = "~/.stno"
+
+func editString(str string) (string, error) {
+	// Create temporary file
+	tmpfile, err := datastore.TempFile("", "stno", ".toml")
+	if err != nil {
+		return str, err
+	}
+	defer os.Remove(tmpfile.Name())
+	if _, err = io.WriteString(tmpfile, str); err != nil {
+		return str, err
+	}
+
+	fi, err := tmpfile.Stat()
+	if err != nil {
+		return str, err
+	}
+	oldModTime := fi.ModTime()
+	if err := tmpfile.Close(); err != nil {
+		return str, err
+	}
+	tmpfile.Close()
+
+	// Open file in editor
+	if err = openEditor(tmpfile.Name()); err != nil {
+		return str, err
+	}
+
+	rc, err := os.Open(tmpfile.Name())
+	if err != nil {
+		return str, err
+	}
+	defer rc.Close()
+
+	// Return original string if there were no changes
+	fi, err = rc.Stat()
+	if err != nil {
+		return str, err
+	}
+	if oldModTime == fi.ModTime() {
+		fmt.Println("Aborting due to no changes.")
+		os.Exit(1)
+	}
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(rc)
+	if err != nil {
+		return str, err
+	}
+	return buf.String(), nil
+}
+
+func openEditor(path string) error {
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "editor"
+	}
+
+	args, err := shellquote.Split(editor)
+	if err != nil {
+		return err
+	}
+
+	editor = args[0]
+	args = append(args[1:], path)
+	cmd := exec.Command(editor, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func confirm() bool {
+	fmt.Printf("(y/N): ")
+	r := bufio.NewReader(os.Stdin)
+	s, err := r.ReadString('\n')
+	if err != nil {
+		panic(err)
+	}
+
+	s = strings.TrimSpace(s)
+	s = strings.ToLower(s)
+
+	if s == "y" || s == "yes" {
+		return true
+	}
+	return false
+}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path"
 
 	homedir "github.com/mitchellh/go-homedir"
 	toml "github.com/pelletier/go-toml"
@@ -10,27 +12,40 @@ import (
 	"github.com/taylorskalyo/stno/datastore"
 )
 
-// queryCmd queries a notebook for a list of entries.
 var queryCmd = &cobra.Command{
-	Use:   "query",
+	Use:   "query [path]",
 	Short: "Query entries and display the results",
-	Long:  `By default query lists all entries.`,
+	Long: `Query entries and display the results
+
+This command takes a path. This path is relative to the stno directory
+(defaults to ~/.stno). By default query lists all entries.`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 1 {
+			return errors.New("query accepts at most one path")
+		}
+		return nil
+	},
 	Run: func(cmd *cobra.Command, args []string) {
+		// Open notebook at the given path
 		dir, err := homedir.Expand(stnoDir)
 		if err != nil {
 			fmt.Printf("Could not expand path %s: %s.\n", stnoDir, err.Error())
 			os.Exit(1)
 		}
-		n := datastore.FileStore{Dir: dir}
+		if len(args) > 0 {
+			dir = path.Join(dir, args[0])
+		}
+		ds := datastore.FileStore{Dir: dir}
 
-		uids, err := n.ListEntries("")
+		// Combine entries into a single TOML tree and display
+		uids, err := ds.ListEntries("")
 		if err != nil {
 			fmt.Printf("Failed to list notebook entries: %s.\n", err.Error())
 			os.Exit(1)
 		}
 		tree, _ := toml.Load("")
 		for _, uid := range uids {
-			rc, err := n.NewEntryReadCloser(uid)
+			rc, err := ds.NewEntryReadCloser(uid)
 			if err != nil {
 				fmt.Printf("Failed to read notebook entry %s: %s.\n", uid, err.Error())
 				os.Exit(1)

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	homedir "github.com/mitchellh/go-homedir"
 	toml "github.com/pelletier/go-toml"
 	"github.com/spf13/cobra"
 	"github.com/taylorskalyo/stno/datastore"
@@ -15,36 +16,32 @@ var queryCmd = &cobra.Command{
 	Short: "Query entries and display the results",
 	Long:  `By default query lists all entries.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		dir, err := stnoDir(notebook)
+		dir, err := homedir.Expand(stnoDir)
 		if err != nil {
-			fmt.Printf("Failed to determine notebook directory: %s.", err.Error())
+			fmt.Printf("Could not expand path %s: %s.\n", stnoDir, err.Error())
 			os.Exit(1)
 		}
-		ds, err := datastore.CreateFileStore(dir)
-		if err != nil {
-			fmt.Printf("Failed to create notebook data store: %s.", err.Error())
-			os.Exit(1)
-		}
+		n := datastore.FileStore{Dir: dir}
 
-		uuids, err := ds.List()
+		uids, err := n.ListEntries("")
 		if err != nil {
-			fmt.Printf("Failed to list notebook entries: %s.", err.Error())
+			fmt.Printf("Failed to list notebook entries: %s.\n", err.Error())
 			os.Exit(1)
 		}
 		tree, _ := toml.Load("")
-		for _, uuid := range uuids {
-			rc, err := ds.NewReadCloser(uuid)
+		for _, uid := range uids {
+			rc, err := n.NewEntryReadCloser(uid)
 			if err != nil {
-				fmt.Printf("Failed to read notebook entry %s: %s.", uuid, err.Error())
+				fmt.Printf("Failed to read notebook entry %s: %s.\n", uid, err.Error())
 				os.Exit(1)
 			}
 			defer rc.Close()
 			t, err := toml.LoadReader(rc)
 			if err != nil {
-				fmt.Printf("Invalid toml in entry %s: %s.", uuid, err.Error())
+				fmt.Printf("Invalid toml in entry %s: %s.\n", uid, err.Error())
 				continue
 			}
-			tree.Set(uuid, "", false, t)
+			tree.Set(uid, "", false, t)
 		}
 		fmt.Println(tree.String())
 	},

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -6,8 +6,9 @@ import (
 
 // DataStore represents a persistent data store for notebooks.
 type DataStore interface {
-	List() ([]string, error)
-	NewUniqueWriteCloser(string) (string, io.WriteCloser, error)
-	NewWriteCloser(string) (io.WriteCloser, error)
-	NewReadCloser(string) (io.ReadCloser, error)
+	ListEntries(string) ([]string, error)
+	NewEntryWriteCloser(string) (io.WriteCloser, error)
+	NewEntryReadCloser(string) (io.ReadCloser, error)
+	RemoveEntry(string) error
+	MoveEntry(string, string) error
 }

--- a/datastore/filestore.go
+++ b/datastore/filestore.go
@@ -69,6 +69,9 @@ func (fs FileStore) listDir(dir string) ([]string, error) {
 // an io.WriteCloser.
 func (fs FileStore) NewEntryWriteCloser(uid string) (io.WriteCloser, error) {
 	pathname := path.Join(fs.Dir, uid+".toml")
+	if err := os.MkdirAll(filepath.Dir(pathname), 0755); err != nil {
+		return nil, err
+	}
 	return os.Create(pathname)
 }
 
@@ -76,9 +79,6 @@ func (fs FileStore) NewEntryWriteCloser(uid string) (io.WriteCloser, error) {
 // io.ReadCloser.
 func (fs FileStore) NewEntryReadCloser(uid string) (io.ReadCloser, error) {
 	pathname := path.Join(fs.Dir, uid+".toml")
-	if err := os.MkdirAll(filepath.Dir(pathname), 0755); err != nil {
-		return nil, err
-	}
 	return os.Open(pathname)
 }
 

--- a/datastore/filestore.go
+++ b/datastore/filestore.go
@@ -6,71 +6,91 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 )
 
-// FileStore implements DataStore using files and directories.
+// FileStore implements DataStore using files and directories. Notebooks and
+// sections within a notebook are represented by directories. Entries are
+// represented by files.
 type FileStore struct {
-	Path string
+	Dir string
 }
 
-// CreateFileStore creates or opens a FileStore at the specified dir.
-func CreateFileStore(dir string) (FileStore, error) {
-	var fs FileStore
+// ListEntries returns the UIDs of each entry in the FileStore.
+func (fs FileStore) ListEntries(prefix string) ([]string, error) {
+	var uids []string
 
-	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return fs, err
+	matches, err := filepath.Glob(path.Join(fs.Dir, prefix+"*"))
+	if err != nil {
+		return uids, err
 	}
-	fs.Path = dir
 
-	return fs, nil
+	for pathname := range matches {
+		fi, err := os.Stat(pathname)
+		if err != nil {
+			return uids, err
+		}
+		if fi.IsDir() {
+			subUIDS, err := listDir(pathname)
+			if err != nil {
+				return uids, err
+			}
+			uids = append(uids, subUIDS)
+		} else {
+			ext := filepath.Ext(pathname)
+			uid := pathname[0 : len(pathname)-len(ext)]
+			uids = append(uids, pathname)
+		}
+	}
+	return uids, nil
 }
 
-// List UUIDs of entries in the FileStore.
-func (fs FileStore) List() ([]string, error) {
-	var uuids []string
+func listDir(dir string) ([]string, error) {
+	var uids []string
 
-	err := filepath.Walk(fs.Path, func(pathname string, fi os.FileInfo, err error) error {
+	err := filepath.Walk(dir, func(pathname string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 		if !fi.IsDir() {
-			base := path.Base(pathname)
-			ext := path.Ext(pathname)
-			if ext != ".toml" {
+			ext := filepath.Ext(pathname)
+			if strings.ToLower(ext) != ".toml" {
 				return nil
 			}
-			uuid := base[0 : len(base)-len(ext)]
-			uuids = append(uuids, uuid)
+			uid := pathname[0 : len(pathname)-len(ext)]
+			uids = append(uids, uid)
 		}
 		return nil
 	})
-
-	return uuids, err
+	return uids, err
 }
 
-// NewUniqueWriteCloser generates a new uuid with an optional prefix and uses it to
-// create an io.WriteCloser.
-func (fs FileStore) NewUniqueWriteCloser(prefix string) (string, io.WriteCloser, error) {
-	f, err := TempFile(fs.Path, prefix, ".toml")
-	if err != nil {
-		return "", f, err
-	}
-
-	return path.Join(fs.Path, f.Name()), f, nil
-}
-
-// NewWriteCloser opens or creates the file with the specified uuid and returns
+// NewEntryWriteCloser opens or creates an entry's underlying file and returns
 // an io.WriteCloser.
-func (fs FileStore) NewWriteCloser(uuid string) (io.WriteCloser, error) {
-	pathname := path.Join(fs.Path, uuid+".toml")
+func (fs FileStore) NewEntryWriteCloser(uid string) (io.WriteCloser, error) {
+	pathname := path.Join(fs.Dir, uid+".toml")
 	return os.Create(pathname)
 }
 
-// NewReadCloser opens the file with the specified uuid and returns an
+// NewEntryReadCloser opens an entry's underlying file and returns an
 // io.ReadCloser.
-func (fs FileStore) NewReadCloser(uuid string) (io.ReadCloser, error) {
-	pathname := path.Join(fs.Path, uuid+".toml")
+func (fs FileStore) NewEntryReadCloser(uid string) (io.ReadCloser, error) {
+	pathname := path.Join(fs.Dir, uid+".toml")
 	return os.Open(pathname)
+}
+
+// Rename renames (moves) an entry's underlying file from srcUID to destUID
+// within the FileStore.
+func (fs FileStore) Rename(srcUID, destUID string) error {
+	srcPath := path.Join(fs.Dir, srcUID+".toml")
+	destPath := path.Join(fs.Dir, destUID+".toml")
+	return os.Rename(srcPath, destPath)
+}
+
+// Remove removes an entry's underlying file from the FileStore.
+func (fs FileStore) Remove(uid string) error {
+	pathname := path.Join(fs.Dir, uid+".toml")
+	return os.Remove(pathname)
 }
 
 // TempFile creates a new temporary file in the directory dir with a name


### PR DESCRIPTION
__What's changing?__

Entry identifiers will be chosen by the user instead of generated based on the entry's contents.

__Why?__

I want the underlying data store for notebooks to be human-readable. Generating unique entry identifiers based on the contents of an entry was complicated and the resulting filenames weren't always friendly-looking. Having the user enter a path each time an entry is added means that entry identifiers will always mean something to the user, and it reduces a lot of the complexity.